### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/AzureDevopsTrainingOrg/a0ef896c-5658-46c8-8f9a-f504a7d9b63c/268ac519-6a52-4ca8-8265-9b8582ec542a/_apis/work/boardbadge/ca6e9bb9-0d24-4774-9d98-417c2c6482ca)](https://dev.azure.com/AzureDevopsTrainingOrg/a0ef896c-5658-46c8-8f9a-f504a7d9b63c/_boards/board/t/268ac519-6a52-4ca8-8265-9b8582ec542a/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#230](https://dev.azure.com/AzureDevopsTrainingOrg/a0ef896c-5658-46c8-8f9a-f504a7d9b63c/_workitems/edit/230). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.